### PR TITLE
27/03/2023 - Carlos - Arreglado error que permitía que la función de ver marcadores se ejecutara continuamente

### DIFF
--- a/webapp/src/components/pod/MarkersPOD.tsx
+++ b/webapp/src/components/pod/MarkersPOD.tsx
@@ -41,11 +41,21 @@ function MarkersPOD() {
     const [points, setPoints] = useState<Point[]>([]);
 
 
-    readFileFromPod(webIdStore,session).then(points => {
-        if(points !== undefined){
-            setPoints(points)
-        }}
-    )
+    // readFileFromPod(webIdStore,session).then(points => {
+    //     if(points !== undefined){
+    //         setPoints(points)
+    //     }}
+    // )
+
+    useEffect(() => {
+        async function fetchPoints() {
+            const newPoints = await readFileFromPod(webIdStore, session);
+            if (newPoints) {
+                setPoints(newPoints);
+            }
+        }
+        fetchPoints();
+    }, [webIdStore, session]);
 
     return(
         <div>


### PR DESCRIPTION
Fixes #185 . Se ha arreglado error que permitía que la función de ver marcadores se ejecutara continuamente